### PR TITLE
Migrate  Saloon from v2 to v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.phar
 composer.lock
 .DS_Store
 database.sqlite
+.phpunit.result.cache
+.idea

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "doctrine/dbal": "^3.6",
         "illuminate/cache": "^10.23",
         "illuminate/database": "^10.23",
-        "saloonphp/laravel-http-sender": "^1.2",
-        "saloonphp/laravel-plugin": "^2.1",
-        "saloonphp/saloon": "^2.11"
+        "saloonphp/laravel-http-sender": "^2.0",
+        "saloonphp/laravel-plugin": "^3.5",
+        "saloonphp/saloon": "^3.5"
     },
     "suggest": {
         "ext-pdo": "Required to extend the PDO driver for Cloudflare D1."

--- a/src/CloudflareConnector.php
+++ b/src/CloudflareConnector.php
@@ -2,6 +2,7 @@
 
 namespace RenokiCo\L1;
 
+use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
 
 abstract class CloudflareConnector extends Connector
@@ -11,7 +12,11 @@ abstract class CloudflareConnector extends Connector
         public ?string $accountId = null,
         public string $apiUrl = 'https://api.cloudflare.com/client/v4',
     ) {
-        $this->withTokenAuth($token);
+    }
+
+    protected function defaultAuth(): TokenAuthenticator
+    {
+        return new TokenAuthenticator($this->token);
     }
 
     public function resolveBaseUrl(): string

--- a/src/CloudflareD1Connector.php
+++ b/src/CloudflareD1Connector.php
@@ -2,7 +2,7 @@
 
 namespace RenokiCo\L1;
 
-use Saloon\Contracts\Response;
+use Saloon\Http\Response;
 
 class CloudflareD1Connector extends CloudflareConnector
 {

--- a/src/CloudflareRequest.php
+++ b/src/CloudflareRequest.php
@@ -2,7 +2,7 @@
 
 namespace RenokiCo\L1;
 
-use Saloon\Contracts\Connector;
+use Saloon\Http\Connector;
 use Saloon\Http\Request;
 
 abstract class CloudflareRequest extends Request


### PR DESCRIPTION
This PR migrated [Saloon](https://docs.saloon.dev/) from v2 to V3 following Saloon [Upgrade Guide](https://docs.saloon.dev/upgrade/upgrading-from-v2).

Laravel Saloon plugin v2  support Laravel `^9.0 || ^10.0` while v3 support Laravel`^10.0 || ^11.0`

Given that this package supports `^10.23`, this PR opens up an opportunity to upgrade the package to [support Laravel 11](https://github.com/renoki-co/l1/pull/56)